### PR TITLE
feat: Added trader and its related models and CRUD APIs for admin

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import sequelize from "./src/database/models/db";
 import userRoutes from "./src/routes/userRoutes";
 import farmerRoutes from "./src/routes/farmerRoutes";
-import coldStorageRoutes from './src/routes/coldStorageRoutes';
+import coldStorageRoutes from "./src/routes/coldStorageRoutes";
 import agentRoutes from "./src/routes/agentRoutes";
 import locationRoutes from "./src/routes/locationRoutes";
 import adminIrrigationRoutes from "./src/routes/adminRoutes/farmer/adminIrrigationRoutes";
@@ -13,7 +13,11 @@ import adminSowingMethodRoutes from "./src/routes/adminRoutes/farmer/adminSowing
 import adminFarmEquipmentRoutes from "./src/routes/adminRoutes/farmer/adminFarmEquipmentUsedRoutes";
 import adminTechnologyUsedRoutes from "./src/routes/adminRoutes/farmer/adminTechnologyUsedRoutes";
 import adminPriceDiscoveryRoutes from "./src/routes/adminRoutes/farmer/adminPriceDiscoveryRoutes";
-import adminBiggestChallengeInSellingRoutes from "./src/routes/adminRoutes/farmer/adminBiggestChallengeInSellingRoutes"
+import adminBiggestChallengeInSellingRoutes from "./src/routes/adminRoutes/farmer/adminBiggestChallengeInSellingRoutes";
+import adminCropTradedRoutes from "./src/routes/adminRoutes/trader/adminCropTradedRoutes";
+import adminTraderInterestRoutes from "./src/routes/adminRoutes/trader/adminTraderInterestRoutes";
+import adminTraderTypeRoutes from "./src/routes/adminRoutes/trader/adminTraderTypeRoutes";
+import adminTraderVarietyRoutes from "./src/routes/adminRoutes/trader/adminTraderVarietyRoutes";
 
 const cors = require("cors");
 
@@ -25,7 +29,7 @@ app.use(express.json());
 app.use("/api/users", userRoutes);
 app.use("/api/farmers", farmerRoutes);
 app.use("/api/cold-storage", coldStorageRoutes);
-app.use("/api/agent",agentRoutes);
+app.use("/api/agent", agentRoutes);
 app.use("/api/locations", locationRoutes);
 app.use("/api/admin/irrigation_source", adminIrrigationRoutes);
 app.use("/api/admin/soil_type", adminSoilTypeRoutes);
@@ -35,7 +39,14 @@ app.use("/api/admin/sowing_method", adminSowingMethodRoutes);
 app.use("/api/admin/farm_equipment", adminFarmEquipmentRoutes);
 app.use("/api/admin/technology_used", adminTechnologyUsedRoutes);
 app.use("/api/admin/price_discovery", adminPriceDiscoveryRoutes);
-app.use("/api/admin/challenge_in_selling", adminBiggestChallengeInSellingRoutes);
+app.use(
+  "/api/admin/challenge_in_selling",
+  adminBiggestChallengeInSellingRoutes
+);
+app.use("/api/admin/crop_traded", adminCropTradedRoutes);
+app.use("/api/admin/trader_interest", adminTraderInterestRoutes);
+app.use("/api/admin/trader_type", adminTraderTypeRoutes);
+app.use("/api/admin/trader_variety", adminTraderVarietyRoutes);
 
 const PORT = 8000;
 const startServer = async () => {

--- a/src/controller/adminController/trader/cropTradedController.ts
+++ b/src/controller/adminController/trader/cropTradedController.ts
@@ -1,0 +1,129 @@
+import AdminCropTraded from "../../../database/models/adminModels/trader/adminCropTraded";
+import {
+  createRecord,
+  getAllRecords,
+  updateRecord,
+  deleteRecord,
+  getRecordById,
+  getActiveRecords,
+} from "../../../services/adminServices/crudOperationService";
+
+export const addCropTraded = async (req, res) => {
+  try {
+    const { role } = req.user;
+    if (role !== "admin") {
+      return res
+        .status(403)
+        .json({ message: "Only admins are allowed to add crop traded." });
+    }
+
+    const response = await createRecord(AdminCropTraded, req.body);
+    if (response.success) {
+      return res.status(201).json({
+        message: "Crop Traded created successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(400).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const getCropTradedById = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const response = await getRecordById(AdminCropTraded, id);
+    if (response.success) {
+      return res.status(200).json({
+        message: "Crop Traded fetched successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(404).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const getCropsTraded = async (req, res) => {
+  try {
+    const response = await getAllRecords(AdminCropTraded);
+    if (response.success) {
+      return res.status(200).json({
+        message: "Crop Traded list fetched successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(400).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const getActiveCropsTraded = async (req, res) => {
+  try {
+    const response = await getActiveRecords(AdminCropTraded);
+
+    if (response.success) {
+      return res.status(200).json({
+        message: "Crop Traded list fetched successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(400).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const updateCropTraded = async (req, res) => {
+  try {
+    const { role } = req.user;
+    if (role !== "admin") {
+      return res
+        .status(403)
+        .json({ message: "Only admins are allowed to update crop traded." });
+    }
+
+    const { id } = req.params;
+    const response = await updateRecord(AdminCropTraded, id, req.body);
+    if (response.success) {
+      return res.status(200).json({
+        message: "Crop Traded updated successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(404).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const deleteCropTraded = async (req, res) => {
+  try {
+    const { role } = req.user;
+    if (role !== "admin") {
+      return res
+        .status(403)
+        .json({ message: "Only admins are allowed to delete crop traded." });
+    }
+
+    const { id } = req.params;
+    const response = await deleteRecord(AdminCropTraded, id);
+    if (response.success) {
+      return res
+        .status(200)
+        .json({ message: "Crop Traded deleted successfully" });
+    }
+
+    return res.status(404).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};

--- a/src/controller/adminController/trader/traderInterestController.ts
+++ b/src/controller/adminController/trader/traderInterestController.ts
@@ -1,0 +1,125 @@
+import AdminTraderInterest from "../../../database/models/adminModels/trader/adminTraderInterest";
+import {
+  createRecord,
+  getAllRecords,
+  updateRecord,
+  deleteRecord,
+  getRecordById,
+  getActiveRecords,
+} from "../../../services/adminServices/crudOperationService";
+
+export const addTraderInterest = async (req, res) => {
+  try {
+    if (req.user.role !== "admin") {
+      return res
+        .status(403)
+        .json({ message: "Only admins can add trader interest." });
+    }
+
+    const response = await createRecord(AdminTraderInterest, req.body);
+    if (response.success) {
+      return res.status(201).json({
+        message: "Trader Interest created successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(400).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const getTraderInterestById = async (req, res) => {
+  try {
+    const response = await getRecordById(AdminTraderInterest, req.params.id);
+    if (response.success)
+      return res.status(200).json({
+        message: "Trader Interest fetched successfully",
+        data: response.data,
+      });
+
+    return res.status(404).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const getTraderInterests = async (req, res) => {
+  try {
+    const response = await getAllRecords(AdminTraderInterest);
+    if (response.success)
+      return res.status(200).json({
+        message: "Trader Interest list fetched successfully",
+        data: response.data,
+      });
+
+    return res.status(400).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const getActiveTraderInterests = async (req, res) => {
+  try {
+    const response = await getActiveRecords(AdminTraderInterest);
+
+    if (response.success) {
+      return res.status(200).json({
+        message: "Trader Interest list fetched successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(400).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const updateTraderInterest = async (req, res) => {
+  try {
+    if (req.user.role !== "admin") {
+      return res
+        .status(403)
+        .json({ message: "Only admins can update trader interest." });
+    }
+
+    const response = await updateRecord(
+      AdminTraderInterest,
+      req.params.id,
+      req.body
+    );
+    if (response.success) {
+      return res.status(200).json({
+        message: "Trader Interest updated successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(404).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const deleteTraderInterest = async (req, res) => {
+  try {
+    if (req.user.role !== "admin") {
+      return res
+        .status(403)
+        .json({ message: "Only admins can delete trader interest." });
+    }
+
+    const response = await deleteRecord(AdminTraderInterest, req.params.id);
+    if (response.success) {
+      return res
+        .status(200)
+        .json({ message: "Trader Interest deleted successfully" });
+    }
+
+    return res.status(404).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};

--- a/src/controller/adminController/trader/traderTypeController.ts
+++ b/src/controller/adminController/trader/traderTypeController.ts
@@ -1,0 +1,99 @@
+import AdminTraderType from "../../../database/models/adminModels/trader/adminTraderType";
+import {
+  createRecord,
+  getAllRecords,
+  updateRecord,
+  deleteRecord,
+  getRecordById,
+  getActiveRecords,
+} from "../../../services/adminServices/crudOperationService";
+
+export const addTraderType = async (req, res) => {
+  if (req.user.role !== "admin") {
+    return res
+      .status(403)
+      .json({ message: "Only admins can add trader type." });
+  }
+
+  const response = await createRecord(AdminTraderType, req.body);
+  if (response.success) {
+    return res.status(201).json({
+      message: "Trader Type created successfully",
+      data: response.data,
+    });
+  }
+
+  return res.status(400).json({ message: response.error });
+};
+
+export const getTraderTypeById = async (req, res) => {
+  const response = await getRecordById(AdminTraderType, req.params.id);
+  if (response.success)
+    return res.status(200).json({
+      message: "Trader Type fetched successfully",
+      data: response.data,
+    });
+  return res.status(404).json({ message: response.error });
+};
+
+export const getTraderTypes = async (_req, res) => {
+  const response = await getAllRecords(AdminTraderType);
+  if (response.success)
+    return res.status(200).json({
+      message: "Trader Type list fetched successfully",
+      data: response.data,
+    });
+  return res.status(400).json({ message: response.error });
+};
+
+export const getActiveTraderTypes = async (req, res) => {
+  try {
+    const response = await getActiveRecords(AdminTraderType);
+
+    if (response.success) {
+      return res.status(200).json({
+        message: "Trader Type list fetched successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(400).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const updateTraderType = async (req, res) => {
+  if (req.user.role !== "admin") {
+    return res
+      .status(403)
+      .json({ message: "Only admins can update trader type." });
+  }
+
+  const response = await updateRecord(AdminTraderType, req.params.id, req.body);
+  if (response.success) {
+    return res.status(200).json({
+      message: "Trader Type updated successfully",
+      data: response.data,
+    });
+  }
+
+  return res.status(404).json({ message: response.error });
+};
+
+export const deleteTraderType = async (req, res) => {
+  if (req.user.role !== "admin") {
+    return res
+      .status(403)
+      .json({ message: "Only admins can delete trader type." });
+  }
+
+  const response = await deleteRecord(AdminTraderType, req.params.id);
+  if (response.success) {
+    return res
+      .status(200)
+      .json({ message: "Trader Type deleted successfully" });
+  }
+
+  return res.status(404).json({ message: response.error });
+};

--- a/src/controller/adminController/trader/traderVarietyController.ts
+++ b/src/controller/adminController/trader/traderVarietyController.ts
@@ -1,0 +1,103 @@
+import AdminTraderVariety from "../../../database/models/adminModels/trader/adminTraderVariety";
+import {
+  createRecord,
+  getAllRecords,
+  updateRecord,
+  deleteRecord,
+  getRecordById,
+  getActiveRecords,
+} from "../../../services/adminServices/crudOperationService";
+
+export const addTraderVariety = async (req, res) => {
+  if (req.user.role !== "admin") {
+    return res
+      .status(403)
+      .json({ message: "Only admins can add trader variety." });
+  }
+
+  const response = await createRecord(AdminTraderVariety, req.body);
+  if (response.success) {
+    return res.status(201).json({
+      message: "Trader Variety created successfully",
+      data: response.data,
+    });
+  }
+
+  return res.status(400).json({ message: response.error });
+};
+
+export const getTraderVarietyById = async (req, res) => {
+  const response = await getRecordById(AdminTraderVariety, req.params.id);
+  if (response.success)
+    return res.status(200).json({
+      message: "Trader Variety fetched successfully",
+      data: response.data,
+    });
+  return res.status(404).json({ message: response.error });
+};
+
+export const getTraderVarieties = async (_req, res) => {
+  const response = await getAllRecords(AdminTraderVariety);
+  if (response.success)
+    return res.status(200).json({
+      message: "Trader Variety list fetched successfully",
+      data: response.data,
+    });
+  return res.status(400).json({ message: response.error });
+};
+
+export const getActiveTraderVarieties = async (req, res) => {
+  try {
+    const response = await getActiveRecords(AdminTraderVariety);
+
+    if (response.success) {
+      return res.status(200).json({
+        message: "Trader Variety list fetched successfully",
+        data: response.data,
+      });
+    }
+
+    return res.status(400).json({ message: response.error });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const updateTraderVariety = async (req, res) => {
+  if (req.user.role !== "admin") {
+    return res
+      .status(403)
+      .json({ message: "Only admins can update trader variety." });
+  }
+
+  const response = await updateRecord(
+    AdminTraderVariety,
+    req.params.id,
+    req.body
+  );
+  if (response.success) {
+    return res.status(200).json({
+      message: "Trader Variety updated successfully",
+      data: response.data,
+    });
+  }
+
+  return res.status(404).json({ message: response.error });
+};
+
+export const deleteTraderVariety = async (req, res) => {
+  if (req.user.role !== "admin") {
+    return res
+      .status(403)
+      .json({ message: "Only admins can delete trader variety." });
+  }
+
+  const response = await deleteRecord(AdminTraderVariety, req.params.id);
+  if (response.success) {
+    return res
+      .status(200)
+      .json({ message: "Trader Variety deleted successfully" });
+  }
+
+  return res.status(404).json({ message: response.error });
+};

--- a/src/database/migrations/20250611082710-create-traders-table.js
+++ b/src/database/migrations/20250611082710-create-traders-table.js
@@ -1,0 +1,159 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("traders", {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      fullName: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      businessName: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      mobileNumber: {
+        type: Sequelize.STRING(15),
+        allowNull: false,
+      },
+      whatsappNumber: {
+        type: Sequelize.STRING(15),
+      },
+      email: {
+        type: Sequelize.STRING,
+      },
+      state: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+      },
+      district: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+      },
+      cityOrVillage: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+      },
+      pinCode: {
+        type: Sequelize.STRING(10),
+        allowNull: false,
+      },
+      languagePreference: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+      },
+      companyRegisteredVendor: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      mainCompany: {
+        type: Sequelize.STRING,
+      },
+      numberOfEmployees: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+      },
+      ownPotatoFarming: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      acres: {
+        type: Sequelize.INTEGER,
+      },
+      yearlyPurchaseVolumeTons: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: false,
+      },
+      mainProcurementRegion: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      geographicalMarketCovered: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      contractFarming: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      spotBuying: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      seedsSales: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      ownColdStorage: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      yearsInTrading: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+      },
+      averageDailySalesKatta: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      salesOwnPotatoes: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      onlineAuctionInterest: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      bankLoanFacility: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      coldStorageAccess: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      acceptsOnlinePayments: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      panNumber: {
+        type: Sequelize.STRING(10),
+        allowNull: false,
+      },
+      gstNumber: {
+        type: Sequelize.STRING(30),
+      },
+      fssaiNumber: {
+        type: Sequelize.STRING(50),
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        references: { model: "users", key: "id" },
+        onDelete: "CASCADE",
+      },
+      onBoardedBy: {
+        type: Sequelize.INTEGER,
+        references: { model: "users", key: "id" },
+        onDelete: "CASCADE",
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("traders");
+  },
+};

--- a/src/database/migrations/20250611111544-create-trader-related-tables.js
+++ b/src/database/migrations/20250611111544-create-trader-related-tables.js
@@ -1,0 +1,286 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // adminTraderVarieties
+    await queryInterface.createTable("adminTraderVarieties", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      variety: { type: Sequelize.STRING(100), allowNull: false },
+      isActive: { type: Sequelize.BOOLEAN, defaultValue: true },
+      position: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // traderVarieties
+    await queryInterface.createTable("traderVarieties", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      traderId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: "traders", key: "id" },
+        onDelete: "CASCADE",
+      },
+      variety: { type: Sequelize.STRING(100), allowNull: false },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // adminTraderTypes
+    await queryInterface.createTable("adminTraderTypes", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      type: { type: Sequelize.STRING(100), allowNull: false },
+      isActive: { type: Sequelize.BOOLEAN, defaultValue: true },
+      position: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // traderTypes
+    await queryInterface.createTable("traderTypes", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      traderId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: "traders", key: "id" },
+        onDelete: "CASCADE",
+      },
+      type: { type: Sequelize.STRING(100), allowNull: false },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // mandiDetails
+    await queryInterface.createTable("mandiDetails", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      traderId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        unique: true,
+        references: { model: "traders", key: "id" },
+        onDelete: "CASCADE",
+      },
+      state: { type: Sequelize.STRING(100), allowNull: false },
+      cityOrVillage: { type: Sequelize.STRING(100), allowNull: false },
+      mandiName: { type: Sequelize.STRING(100), allowNull: false },
+      shopNumber: { type: Sequelize.STRING(50) },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // adminCropsTraded
+    await queryInterface.createTable("adminCropsTraded", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      cropName: { type: Sequelize.STRING(100), allowNull: false },
+      isActive: { type: Sequelize.BOOLEAN, defaultValue: true },
+      position: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // cropsTraded
+    await queryInterface.createTable("cropsTraded", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      traderId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: "traders", key: "id" },
+        onDelete: "CASCADE",
+      },
+      cropName: { type: Sequelize.STRING(100), allowNull: false },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // bankDetails
+    await queryInterface.createTable("bankDetails", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      traderId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        unique: true,
+        references: { model: "traders", key: "id" },
+        onDelete: "CASCADE",
+      },
+      bankName: { type: Sequelize.STRING(255), allowNull: false },
+      accountNumber: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+        unique: true,
+      },
+      ifscCode: { type: Sequelize.STRING(20), allowNull: false },
+      upiId: { type: Sequelize.STRING(100), unique: true },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // adminTraderInterests
+    await queryInterface.createTable("adminTraderInterests", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      interest: { type: Sequelize.STRING(100), allowNull: false },
+      isActive: { type: Sequelize.BOOLEAN, defaultValue: true },
+      position: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // traderInterests
+    await queryInterface.createTable("traderInterests", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      traderId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: "traders", key: "id" },
+        onDelete: "CASCADE",
+      },
+      interest: { type: Sequelize.STRING(100), allowNull: false },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    // traderDocuments
+    await queryInterface.createTable("traderDocuments", {
+      id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      traderId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        unique: true,
+        references: { model: "traders", key: "id" },
+        onDelete: "CASCADE",
+      },
+      panCardUrl: { type: Sequelize.TEXT },
+      businessCardUrl: { type: Sequelize.TEXT },
+      tradeLicenseUrl: { type: Sequelize.TEXT },
+      recentInvoiceUrl: { type: Sequelize.TEXT },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+    });
+
+    await queryInterface.addIndex("traderVarieties", ["traderId", "variety"], {
+      unique: true,
+    });
+    await queryInterface.addIndex("traderTypes", ["traderId", "type"], {
+      unique: true,
+    });
+    await queryInterface.addIndex("cropsTraded", ["traderId", "cropName"], {
+      unique: true,
+    });
+    await queryInterface.addIndex("traderInterests", ["traderId", "interest"], {
+      unique: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("traderDocuments");
+    await queryInterface.dropTable("traderInterests");
+    await queryInterface.dropTable("adminTraderInterests");
+    await queryInterface.dropTable("bankDetails");
+    await queryInterface.dropTable("cropsTraded");
+    await queryInterface.dropTable("adminCropsTraded");
+    await queryInterface.dropTable("mandiDetails");
+    await queryInterface.dropTable("traderTypes");
+    await queryInterface.dropTable("adminTraderTypes");
+    await queryInterface.dropTable("traderVarieties");
+    await queryInterface.dropTable("adminTraderVarieties");
+  },
+};

--- a/src/database/models/adminModels/trader/adminCropTraded.ts
+++ b/src/database/models/adminModels/trader/adminCropTraded.ts
@@ -1,0 +1,50 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+} from "sequelize";
+import sequelize from "../../db";
+
+class AdminCropTraded extends Model<
+  InferAttributes<AdminCropTraded>,
+  InferCreationAttributes<AdminCropTraded>
+> {
+  declare id: CreationOptional<number>;
+  declare cropName: string;
+  declare isActive: CreationOptional<boolean>;
+  declare position: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+AdminCropTraded.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    cropName: { type: DataTypes.STRING(100), allowNull: false },
+    isActive: { type: DataTypes.BOOLEAN, defaultValue: true },
+    position: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "AdminCropTraded",
+    tableName: "adminCropsTraded",
+    timestamps: true,
+  }
+);
+
+export default AdminCropTraded;

--- a/src/database/models/adminModels/trader/adminTraderInterest.ts
+++ b/src/database/models/adminModels/trader/adminTraderInterest.ts
@@ -1,0 +1,50 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+} from "sequelize";
+import sequelize from "../../db";
+
+class AdminTraderInterest extends Model<
+  InferAttributes<AdminTraderInterest>,
+  InferCreationAttributes<AdminTraderInterest>
+> {
+  declare id: CreationOptional<number>;
+  declare interest: string;
+  declare isActive: CreationOptional<boolean>;
+  declare position: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+AdminTraderInterest.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    interest: { type: DataTypes.STRING(100), allowNull: false },
+    isActive: { type: DataTypes.BOOLEAN, defaultValue: true },
+    position: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "AdminTraderInterest",
+    tableName: "adminTraderInterests",
+    timestamps: true,
+  }
+);
+
+export default AdminTraderInterest;

--- a/src/database/models/adminModels/trader/adminTraderType.ts
+++ b/src/database/models/adminModels/trader/adminTraderType.ts
@@ -1,0 +1,50 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+} from "sequelize";
+import sequelize from "../../db";
+
+class AdminTraderType extends Model<
+  InferAttributes<AdminTraderType>,
+  InferCreationAttributes<AdminTraderType>
+> {
+  declare id: CreationOptional<number>;
+  declare type: string;
+  declare isActive: CreationOptional<boolean>;
+  declare position: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+AdminTraderType.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    type: { type: DataTypes.STRING(100), allowNull: false },
+    isActive: { type: DataTypes.BOOLEAN, defaultValue: true },
+    position: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "AdminTraderType",
+    tableName: "adminTraderTypes",
+    timestamps: true,
+  }
+);
+
+export default AdminTraderType;

--- a/src/database/models/adminModels/trader/adminTraderVariety.ts
+++ b/src/database/models/adminModels/trader/adminTraderVariety.ts
@@ -1,0 +1,50 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+} from "sequelize";
+import sequelize from "../../db";
+
+class AdminTraderVariety extends Model<
+  InferAttributes<AdminTraderVariety>,
+  InferCreationAttributes<AdminTraderVariety>
+> {
+  declare id: CreationOptional<number>;
+  declare variety: string;
+  declare isActive: CreationOptional<boolean>;
+  declare position: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+AdminTraderVariety.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    variety: { type: DataTypes.STRING(100), allowNull: false },
+    isActive: { type: DataTypes.BOOLEAN, defaultValue: true },
+    position: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "AdminTraderVariety",
+    tableName: "adminTraderVarieties",
+    timestamps: true,
+  }
+);
+
+export default AdminTraderVariety;

--- a/src/database/models/trader/bankDetail.ts
+++ b/src/database/models/trader/bankDetail.ts
@@ -1,0 +1,66 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import sequelize from "../db";
+import Trader from "./trader";
+
+class BankDetail extends Model<
+  InferAttributes<BankDetail>,
+  InferCreationAttributes<BankDetail>
+> {
+  declare id: CreationOptional<number>;
+  declare traderId: ForeignKey<Trader["id"]>;
+  declare bankName: string;
+  declare accountNumber: string;
+  declare ifscCode: string;
+  declare upiId: string | null;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+BankDetail.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    traderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      unique: true,
+      references: { model: "traders", key: "id" },
+      onDelete: "CASCADE",
+    },
+    bankName: { type: DataTypes.STRING(255), allowNull: false },
+    accountNumber: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+      unique: true,
+    },
+    ifscCode: { type: DataTypes.STRING(20), allowNull: false },
+    upiId: { type: DataTypes.STRING(100), unique: true },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "BankDetail",
+    tableName: "bankDetails",
+    timestamps: true,
+  }
+);
+
+BankDetail.belongsTo(Trader, { foreignKey: "traderId", as: "trader" });
+Trader.hasOne(BankDetail, { foreignKey: "traderId", as: "bankDetail" });
+
+export default BankDetail;

--- a/src/database/models/trader/cropTraded.ts
+++ b/src/database/models/trader/cropTraded.ts
@@ -1,0 +1,61 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import sequelize from "../db";
+import Trader from "./trader";
+
+class CropTraded extends Model<
+  InferAttributes<CropTraded>,
+  InferCreationAttributes<CropTraded>
+> {
+  declare id: CreationOptional<number>;
+  declare traderId: ForeignKey<Trader["id"]>;
+  declare cropName: string;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+CropTraded.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    traderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: { model: "traders", key: "id" },
+      onDelete: "CASCADE",
+    },
+    cropName: { type: DataTypes.STRING(100), allowNull: false },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "CropTraded",
+    tableName: "cropsTraded",
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ["traderId", "cropName"],
+      },
+    ],
+  }
+);
+
+CropTraded.belongsTo(Trader, { foreignKey: "traderId", as: "trader" });
+Trader.hasMany(CropTraded, { foreignKey: "traderId", as: "cropsTraded" });
+
+export default CropTraded;

--- a/src/database/models/trader/mandiDetail.ts
+++ b/src/database/models/trader/mandiDetail.ts
@@ -1,0 +1,62 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import sequelize from "../db";
+import Trader from "./trader";
+
+class MandiDetail extends Model<
+  InferAttributes<MandiDetail>,
+  InferCreationAttributes<MandiDetail>
+> {
+  declare id: CreationOptional<number>;
+  declare traderId: ForeignKey<Trader["id"]>;
+  declare state: string;
+  declare cityOrVillage: string;
+  declare mandiName: string;
+  declare shopNumber: string | null;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+MandiDetail.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    traderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      unique: true,
+      references: { model: "traders", key: "id" },
+      onDelete: "CASCADE",
+    },
+    state: { type: DataTypes.STRING(100), allowNull: false },
+    cityOrVillage: { type: DataTypes.STRING(100), allowNull: false },
+    mandiName: { type: DataTypes.STRING(100), allowNull: false },
+    shopNumber: { type: DataTypes.STRING(50) },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "MandiDetail",
+    tableName: "mandiDetails",
+    timestamps: true,
+  }
+);
+
+MandiDetail.belongsTo(Trader, { foreignKey: "traderId", as: "trader" });
+Trader.hasOne(MandiDetail, { foreignKey: "traderId", as: "mandiDetail" });
+
+export default MandiDetail;

--- a/src/database/models/trader/trader.ts
+++ b/src/database/models/trader/trader.ts
@@ -1,0 +1,227 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import sequelize from "../db";
+import User from "../user";
+
+class Trader extends Model<
+  InferAttributes<Trader>,
+  InferCreationAttributes<Trader>
+> {
+  declare id: CreationOptional<number>;
+  declare fullName: string;
+  declare businessName: string;
+  declare mobileNumber: string;
+  declare whatsappNumber: string | null;
+  declare email: string | null;
+  declare state: string;
+  declare district: string;
+  declare cityOrVillage: string;
+  declare pinCode: string;
+  declare languagePreference: string;
+  declare companyRegisteredVendor: boolean;
+  declare mainCompany: string | null;
+  declare numberOfEmployees: string;
+  declare ownPotatoFarming: boolean;
+  declare acres: number | null;
+  declare yearlyPurchaseVolumeTons: number;
+  declare mainProcurementRegion: string;
+  declare geographicalMarketCovered: string;
+  declare contractFarming: boolean;
+  declare spotBuying: boolean;
+  declare seedsSales: boolean;
+  declare ownColdStorage: boolean;
+  declare yearsInTrading: string;
+  declare averageDailySalesKatta: number;
+  declare salesOwnPotatoes: boolean;
+  declare onlineAuctionInterest: boolean;
+  declare bankLoanFacility: boolean;
+  declare coldStorageAccess: boolean;
+  declare acceptsOnlinePayments: boolean;
+  declare panNumber: string;
+  declare gstNumber: string | null;
+  declare fssaiNumber: string | null;
+  declare userId: ForeignKey<User["id"]> | null;
+  declare onBoardedBy: ForeignKey<User["id"]> | null;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+Trader.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    fullName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    businessName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    mobileNumber: {
+      type: DataTypes.STRING(15),
+      allowNull: false,
+    },
+    whatsappNumber: {
+      type: DataTypes.STRING(15),
+      allowNull: true,
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    state: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    district: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    cityOrVillage: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    pinCode: {
+      type: DataTypes.STRING(10),
+      allowNull: false,
+    },
+    languagePreference: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+    },
+    companyRegisteredVendor: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    mainCompany: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    numberOfEmployees: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+    },
+    ownPotatoFarming: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    acres: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    yearlyPurchaseVolumeTons: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: false,
+    },
+    mainProcurementRegion: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    geographicalMarketCovered: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    contractFarming: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    spotBuying: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    seedsSales: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    ownColdStorage: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    yearsInTrading: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+    },
+    averageDailySalesKatta: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    salesOwnPotatoes: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    onlineAuctionInterest: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    bankLoanFacility: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    coldStorageAccess: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    acceptsOnlinePayments: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    panNumber: {
+      type: DataTypes.STRING(10),
+      allowNull: false,
+    },
+    gstNumber: {
+      type: DataTypes.STRING(30),
+      allowNull: true,
+    },
+    fssaiNumber: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: "users",
+        key: "id",
+      },
+      onDelete: "CASCADE",
+    },
+    onBoardedBy: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: "users",
+        key: "id",
+      },
+      onDelete: "CASCADE",
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize,
+    modelName: "Trader",
+    tableName: "traders",
+    timestamps: true,
+  }
+);
+
+export default Trader;

--- a/src/database/models/trader/traderDocument.ts
+++ b/src/database/models/trader/traderDocument.ts
@@ -1,0 +1,62 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import sequelize from "../db";
+import Trader from "./trader";
+
+class TraderDocument extends Model<
+  InferAttributes<TraderDocument>,
+  InferCreationAttributes<TraderDocument>
+> {
+  declare id: CreationOptional<number>;
+  declare traderId: ForeignKey<Trader["id"]>;
+  declare panCardUrl: string | null;
+  declare businessCardUrl: string | null;
+  declare tradeLicenseUrl: string | null;
+  declare recentInvoiceUrl: string | null;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+TraderDocument.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    traderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      unique: true,
+      references: { model: "traders", key: "id" },
+      onDelete: "CASCADE",
+    },
+    panCardUrl: { type: DataTypes.TEXT },
+    businessCardUrl: { type: DataTypes.TEXT },
+    tradeLicenseUrl: { type: DataTypes.TEXT },
+    recentInvoiceUrl: { type: DataTypes.TEXT },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "TraderDocument",
+    tableName: "traderDocuments",
+    timestamps: true,
+  }
+);
+
+TraderDocument.belongsTo(Trader, { foreignKey: "traderId", as: "trader" });
+Trader.hasOne(TraderDocument, { foreignKey: "traderId", as: "document" });
+
+export default TraderDocument;

--- a/src/database/models/trader/traderInterest.ts
+++ b/src/database/models/trader/traderInterest.ts
@@ -1,0 +1,64 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import sequelize from "../db";
+import Trader from "./trader";
+
+class TraderInterest extends Model<
+  InferAttributes<TraderInterest>,
+  InferCreationAttributes<TraderInterest>
+> {
+  declare id: CreationOptional<number>;
+  declare traderId: ForeignKey<Trader["id"]>;
+  declare interest: string;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+TraderInterest.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    traderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: { model: "traders", key: "id" },
+      onDelete: "CASCADE",
+    },
+    interest: { type: DataTypes.STRING(100), allowNull: false },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "TraderInterest",
+    tableName: "traderInterests",
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ["traderId", "interest"],
+      },
+    ],
+  }
+);
+
+TraderInterest.belongsTo(Trader, { foreignKey: "traderId", as: "trader" });
+Trader.hasMany(TraderInterest, {
+  foreignKey: "traderId",
+  as: "traderInterests",
+});
+
+export default TraderInterest;

--- a/src/database/models/trader/traderType.ts
+++ b/src/database/models/trader/traderType.ts
@@ -1,0 +1,61 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import sequelize from "../db";
+import Trader from "./trader";
+
+class TraderType extends Model<
+  InferAttributes<TraderType>,
+  InferCreationAttributes<TraderType>
+> {
+  declare id: CreationOptional<number>;
+  declare traderId: ForeignKey<Trader["id"]>;
+  declare type: string;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+TraderType.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    traderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: { model: "traders", key: "id" },
+      onDelete: "CASCADE",
+    },
+    type: { type: DataTypes.STRING(100), allowNull: false },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "TraderType",
+    tableName: "traderTypes",
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ["traderId", "type"],
+      },
+    ],
+  }
+);
+
+TraderType.belongsTo(Trader, { foreignKey: "traderId", as: "trader" });
+Trader.hasMany(TraderType, { foreignKey: "traderId", as: "traderTypes" });
+
+export default TraderType;

--- a/src/database/models/trader/traderVariety.ts
+++ b/src/database/models/trader/traderVariety.ts
@@ -1,0 +1,61 @@
+import {
+  Model,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import sequelize from "../db";
+import Trader from "./trader";
+
+class TraderVariety extends Model<
+  InferAttributes<TraderVariety>,
+  InferCreationAttributes<TraderVariety>
+> {
+  declare id: CreationOptional<number>;
+  declare traderId: ForeignKey<Trader["id"]>;
+  declare variety: string;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+TraderVariety.init(
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    traderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: { model: "traders", key: "id" },
+      onDelete: "CASCADE",
+    },
+    variety: { type: DataTypes.STRING(100), allowNull: false },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "TraderVariety",
+    tableName: "traderVarieties",
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ["traderId", "variety"],
+      },
+    ],
+  }
+);
+
+TraderVariety.belongsTo(Trader, { foreignKey: "traderId", as: "trader" });
+Trader.hasMany(TraderVariety, { foreignKey: "traderId", as: "traderVarieties" });
+
+export default TraderVariety;

--- a/src/routes/adminRoutes/trader/adminCropTradedRoutes.ts
+++ b/src/routes/adminRoutes/trader/adminCropTradedRoutes.ts
@@ -1,0 +1,42 @@
+import { createValidator } from "express-joi-validation";
+import express from "express";
+import { authMiddleware } from "../../../utils/userAuth";
+import {
+  addCropTraded,
+  deleteCropTraded,
+  getActiveCropsTraded,
+  getCropsTraded,
+  getCropTradedById,
+  updateCropTraded,
+} from "../../../controller/adminController/trader/cropTradedController";
+import {
+  cropTradedCreateSchema,
+  cropTradedUpdateSchema,
+} from "../../../validation/adminTraderValidation";
+
+const router = express.Router();
+const validator = createValidator({});
+
+router.post(
+  "/",
+  authMiddleware,
+  validator.body(cropTradedCreateSchema),
+  addCropTraded
+);
+
+router.get("/", authMiddleware, getCropsTraded);
+
+router.get("/active", authMiddleware, getActiveCropsTraded);
+
+router.get("/:id", authMiddleware, getCropTradedById);
+
+router.put(
+  "/:id",
+  authMiddleware,
+  validator.body(cropTradedUpdateSchema),
+  updateCropTraded
+);
+
+router.delete("/:id", authMiddleware, deleteCropTraded);
+
+export default router;

--- a/src/routes/adminRoutes/trader/adminTraderInterestRoutes.ts
+++ b/src/routes/adminRoutes/trader/adminTraderInterestRoutes.ts
@@ -1,0 +1,42 @@
+import { createValidator } from "express-joi-validation";
+import express from "express";
+import { authMiddleware } from "../../../utils/userAuth";
+import {
+  addTraderInterest,
+  deleteTraderInterest,
+  getTraderInterests,
+  getTraderInterestById,
+  updateTraderInterest,
+  getActiveTraderInterests,
+} from "../../../controller/adminController/trader/traderInterestController";
+import {
+  traderInterestCreateSchema,
+  traderInterestUpdateSchema,
+} from "../../../validation/adminTraderValidation";
+
+const router = express.Router();
+const validator = createValidator({});
+
+router.post(
+  "/",
+  authMiddleware,
+  validator.body(traderInterestCreateSchema),
+  addTraderInterest
+);
+
+router.get("/", authMiddleware, getTraderInterests);
+
+router.get("/active", authMiddleware, getActiveTraderInterests);
+
+router.get("/:id", authMiddleware, getTraderInterestById);
+
+router.put(
+  "/:id",
+  authMiddleware,
+  validator.body(traderInterestUpdateSchema),
+  updateTraderInterest
+);
+
+router.delete("/:id", authMiddleware, deleteTraderInterest);
+
+export default router;

--- a/src/routes/adminRoutes/trader/adminTraderTypeRoutes.ts
+++ b/src/routes/adminRoutes/trader/adminTraderTypeRoutes.ts
@@ -1,0 +1,42 @@
+import { createValidator } from "express-joi-validation";
+import express from "express";
+import { authMiddleware } from "../../../utils/userAuth";
+import {
+  addTraderType,
+  deleteTraderType,
+  getTraderTypes,
+  getTraderTypeById,
+  updateTraderType,
+  getActiveTraderTypes,
+} from "../../../controller/adminController/trader/traderTypeController";
+import {
+  traderTypeCreateSchema,
+  traderTypeUpdateSchema,
+} from "../../../validation/adminTraderValidation";
+
+const router = express.Router();
+const validator = createValidator({});
+
+router.post(
+  "/",
+  authMiddleware,
+  validator.body(traderTypeCreateSchema),
+  addTraderType
+);
+
+router.get("/", authMiddleware, getTraderTypes);
+
+router.get("/active", authMiddleware, getActiveTraderTypes);
+
+router.get("/:id", authMiddleware, getTraderTypeById);
+
+router.put(
+  "/:id",
+  authMiddleware,
+  validator.body(traderTypeUpdateSchema),
+  updateTraderType
+);
+
+router.delete("/:id", authMiddleware, deleteTraderType);
+
+export default router;

--- a/src/routes/adminRoutes/trader/adminTraderVarietyRoutes.ts
+++ b/src/routes/adminRoutes/trader/adminTraderVarietyRoutes.ts
@@ -1,0 +1,42 @@
+import { createValidator } from "express-joi-validation";
+import express from "express";
+import { authMiddleware } from "../../../utils/userAuth";
+import {
+  addTraderVariety,
+  deleteTraderVariety,
+  getActiveTraderVarieties,
+  getTraderVarieties,
+  getTraderVarietyById,
+  updateTraderVariety,
+} from "../../../controller/adminController/trader/traderVarietyController";
+import {
+  traderVarietyCreateSchema,
+  traderVarietyUpdateSchema,
+} from "../../../validation/adminTraderValidation";
+
+const router = express.Router();
+const validator = createValidator({});
+
+router.post(
+  "/",
+  authMiddleware,
+  validator.body(traderVarietyCreateSchema),
+  addTraderVariety
+);
+
+router.get("/", authMiddleware, getTraderVarieties);
+
+router.get("/active", authMiddleware, getActiveTraderVarieties);
+
+router.get("/:id", authMiddleware, getTraderVarietyById);
+
+router.put(
+  "/:id",
+  authMiddleware,
+  validator.body(traderVarietyUpdateSchema),
+  updateTraderVariety
+);
+
+router.delete("/:id", authMiddleware, deleteTraderVariety);
+
+export default router;

--- a/src/services/adminServices/crudOperationService.ts
+++ b/src/services/adminServices/crudOperationService.ts
@@ -7,6 +7,7 @@ const updateModelFields = async (modelInstance, data) => {
   await modelInstance.save();
   return modelInstance;
 };
+
 export const updateRecord = async (modelClass, id, data) => {
   try {
     const instance = await modelClass.findByPk(id);
@@ -28,6 +29,7 @@ export const updateRecord = async (modelClass, id, data) => {
     };
   }
 };
+
 export const createRecord = async (model, data) => {
   try {
     const result = await model.create(data);
@@ -43,6 +45,7 @@ export const createRecord = async (model, data) => {
     };
   }
 };
+
 export const getActiveRecords = async (model) => {
   try {
     const result = await model.findAll({
@@ -61,6 +64,7 @@ export const getActiveRecords = async (model) => {
     };
   }
 };
+
 export const getAllRecords = async (model) => {
   try {
     const result = await model.findAll();
@@ -76,6 +80,7 @@ export const getAllRecords = async (model) => {
     };
   }
 };
+
 export const getRecordById = async (model, id) => {
   try {
     const result = await model.findByPk(id);
@@ -85,6 +90,7 @@ export const getRecordById = async (model, id) => {
         error: `Record not found with ID: ${id}.`,
       };
     }
+
     return {
       success: true,
       data: result,
@@ -97,6 +103,7 @@ export const getRecordById = async (model, id) => {
     };
   }
 };
+
 export const deleteRecord = async (model, id) => {
   try {
     const result = await model.findByPk(id);

--- a/src/validation/adminTraderValidation.ts
+++ b/src/validation/adminTraderValidation.ts
@@ -1,0 +1,49 @@
+import Joi from "joi";
+
+export const cropTradedCreateSchema = Joi.object({
+  cropName: Joi.string().required(),
+  isActive: Joi.boolean().optional(),
+  position: Joi.number().optional(),
+});
+
+export const cropTradedUpdateSchema = Joi.object({
+  cropName: Joi.string().optional(),
+  isActive: Joi.boolean().optional(),
+  position: Joi.number().optional(),
+});
+
+export const traderInterestCreateSchema = Joi.object({
+  interest: Joi.string().required(),
+  isActive: Joi.boolean().optional(),
+  position: Joi.number().optional(),
+});
+
+export const traderInterestUpdateSchema = Joi.object({
+  interest: Joi.string().optional(),
+  isActive: Joi.boolean().optional(),
+  position: Joi.number().optional(),
+});
+
+export const traderTypeCreateSchema = Joi.object({
+  type: Joi.string().required(),
+  isActive: Joi.boolean().optional(),
+  position: Joi.number().optional(),
+});
+
+export const traderTypeUpdateSchema = Joi.object({
+  type: Joi.string().optional(),
+  isActive: Joi.boolean().optional(),
+  position: Joi.number().optional(),
+});
+
+export const traderVarietyCreateSchema = Joi.object({
+  variety: Joi.string().required(),
+  isActive: Joi.boolean().optional(),
+  position: Joi.number().optional(),
+});
+
+export const traderVarietyUpdateSchema = Joi.object({
+  variety: Joi.string().optional(),
+  isActive: Joi.boolean().optional(),
+  position: Joi.number().optional(),
+});


### PR DESCRIPTION
Designed database schema for trader registration (trader and its related schemas) like
- traders
- traderVarieties
- adminTraderVarieties
- adminTraderTypes
- traderTypes
- mandiDetails
- cropTraded
- bankDetails
- adminTraderInterests
- traderInterests
- traderDocuments

Apply schema level validations in trader related schemas
Make associations throught the app realted to trader
Make CRUD apis for admin adminTraderVarieties, adminTraderTypes, adminTraderInterests, adminCropsTraded
