### PR TITLE
fix: optional value for agent update

### DIFF
--- a/src/validation/agentValidation.ts
+++ b/src/validation/agentValidation.ts
@@ -1,16 +1,16 @@
 import Joi from "joi";
 
 export const updateAgentSchema = Joi.object({
-  name: Joi.string().optional(),
-  email: Joi.string().email().optional(),
-  mobile: Joi.string().optional(),
+  name: Joi.string().optional().allow(null, ""),
+  email: Joi.string().email().optional().allow(null),
+  mobile: Joi.string().optional().allow(null),
 
-  phone: Joi.string().optional(),
-  address: Joi.string().optional().allow(""),
-  state: Joi.string().optional(),
-  district: Joi.string().optional(),
-  note: Joi.string().optional().allow(""),
-  isActive: Joi.boolean().optional(),
+  phone: Joi.string().optional().allow(null),
+  address: Joi.string().optional().allow(null, ""),
+  state: Joi.string().allow(null, ""),
+  district: Joi.string().allow(null, ""),
+  note: Joi.string().optional().allow(null, ""),
+  isActive: Joi.boolean().optional().allow(null),
 });
 
 export const agentMonthlyTargetSchema = Joi.object({
@@ -32,8 +32,8 @@ export const agentMonthlyTargetSchema = Joi.object({
       "Nov",
       "Dec"
     ),
-  farmerMonthlyTarget: Joi.number().optional(),
-  coldStorageMonthlyTarget: Joi.number().optional(),
-  traderMonthlyTarget: Joi.number().optional(),
+  farmerMonthlyTarget: Joi.number().optional().allow(null),
+  coldStorageMonthlyTarget: Joi.number().optional().allow(null),
+  traderMonthlyTarget: Joi.number().optional().allow(null),
   isEdit: Joi.boolean().optional().default(false),
 });

--- a/src/validation/userValidator.ts
+++ b/src/validation/userValidator.ts
@@ -45,8 +45,8 @@ export const loginSchema = Joi.object({
 
 export const createAgentSchema = Joi.object({
   name: Joi.string().required(),
-  email: Joi.string().email().optional().allow(null, ""),
-  phone: Joi.string().optional().allow(null, ""),
+  email: Joi.string().email().optional().allow(null),
+  phone: Joi.string().optional().allow(null),
   address: Joi.string().optional().allow(null, ""),
   district: Joi.string().optional().allow(null, ""),
   state: Joi.string().optional().allow(null, ""),


### PR DESCRIPTION
 allowed null values for email and phone for user or agent as email and phone are kept unique in user table which gives error for  empty string values.