### PR TITLE
fix: trim name fields in onboarding form and add OTP rate limit for mobile update request APIs

### DIFF
--- a/src/routes/coldStorageRoutes.ts
+++ b/src/routes/coldStorageRoutes.ts
@@ -26,6 +26,7 @@ import { verifyOtpSchema } from "../validation/userValidator";
 import { WEB_ACTIONS, WEB_MODULES } from "../utils/constants/permissions";
 import { duplicationCheckMiddleware } from "../middlewares/duplicationCheckMiddleware";
 import ColdStorage from "../database/models/coldStorage";
+import { limitOtpMiddleware } from "../utils/limitOtpRequest";
 
 const router = express.Router();
 const validator = createValidator({});
@@ -94,6 +95,7 @@ router.post(
     WEB_ACTIONS.UPDATE,
     false
   ),
+  limitOtpMiddleware,
   requestUpdateCS
 );
 

--- a/src/routes/farmerRoutes.ts
+++ b/src/routes/farmerRoutes.ts
@@ -26,6 +26,7 @@ import { verifyOtpSchema } from "../validation/userValidator";
 import { WEB_ACTIONS, WEB_MODULES } from "../utils/constants/permissions";
 import { duplicationCheckMiddleware } from "../middlewares/duplicationCheckMiddleware";
 import Farmer from "../database/models/farmer";
+import { limitOtpMiddleware } from "../utils/limitOtpRequest";
 
 const router = express.Router();
 const validator = createValidator({});
@@ -70,6 +71,7 @@ router.post(
 router.post(
   "/:farmerId/request-mobile-update",
   checkWebPermissionMiddleware(WEB_MODULES.FARMER, WEB_ACTIONS.UPDATE, false),
+  limitOtpMiddleware,
   requestUpdateFarmer
 );
 

--- a/src/routes/traderRoutes.ts
+++ b/src/routes/traderRoutes.ts
@@ -25,6 +25,7 @@ import { verifyOtpSchema } from "../validation/userValidator";
 import { WEB_ACTIONS, WEB_MODULES } from "../utils/constants/permissions";
 import { duplicationCheckMiddleware } from "../middlewares/duplicationCheckMiddleware";
 import Trader from "../database/models/trader/trader";
+import { limitOtpMiddleware } from "../utils/limitOtpRequest";
 
 const router = express.Router();
 const validator = createValidator({});
@@ -76,6 +77,7 @@ router.post(
 router.post(
   "/:traderId/request-mobile-update",
   checkWebPermissionMiddleware(WEB_MODULES.TRADER, WEB_ACTIONS.UPDATE, false),
+  limitOtpMiddleware,
   requestUpdateTrader
 );
 

--- a/src/utils/limitOtpRequest.ts
+++ b/src/utils/limitOtpRequest.ts
@@ -3,13 +3,21 @@ import Otp from "../database/models/otp";
 
 export const limitOtpMiddleware = async (req, res, next) => {
   try {
-    const { mobile } = req.body;
+    const { mobile, newMobileNumber } = req.body;
+    const targetMobile = mobile || newMobileNumber;
+
+    if (!targetMobile) {
+      return res.status(400).json({
+        success: false,
+        message: "Mobile number is required.",
+      });
+    }
 
     const twentyMinutesAgo = new Date(Date.now() - 20 * 60 * 1000);
 
     const otps = await Otp.findAll({
       where: {
-        mobile,
+        mobile: targetMobile,
         createdAt: { [Op.gte]: twentyMinutesAgo },
       },
     });

--- a/src/validation/coldStorageValidation.ts
+++ b/src/validation/coldStorageValidation.ts
@@ -1,9 +1,9 @@
 import Joi from "joi";
 
 export const coldStorageSchema = Joi.object({
-  name: Joi.string().max(255).required(),
-  firstName: Joi.string().max(255).required(),
-  lastName: Joi.string().max(255).required(),
+  name: Joi.string().trim().max(255).required(),
+  firstName: Joi.string().trim().max(255).required(),
+  lastName: Joi.string().trim().max(255).required(),
   ownerName: Joi.string().max(255).optional(),
   mobileNumber: Joi.string().max(255).required(),
   optionalNumber: Joi.string().max(255).allow("", null),
@@ -315,9 +315,9 @@ export const coldStorageSchema = Joi.object({
 });
 
 export const updateColdStorageSchema = Joi.object({
-  name: Joi.string().max(255).optional().allow("", null),
-  firstName: Joi.string().max(255).optional().allow(null, ""),
-  lastName: Joi.string().max(255).optional().allow(null, ""),
+  name: Joi.string().trim().max(255).optional().allow("", null),
+  firstName: Joi.string().trim().max(255).optional().allow(null, ""),
+  lastName: Joi.string().trim().max(255).optional().allow(null, ""),
   ownerName: Joi.string().max(255).optional().allow("", null),
   mobileNumber: Joi.string().max(255).optional().allow("", null),
   optionalNumber: Joi.string().max(255).allow("", null),

--- a/src/validation/farmerValidation.ts
+++ b/src/validation/farmerValidation.ts
@@ -1,9 +1,9 @@
 import Joi from "joi";
 
 export const onboardFarmerSchema = Joi.object({
-  name: Joi.string().max(255).optional(),
-  firstName: Joi.string().max(255).required(),
-  lastName: Joi.string().max(255).required(),
+  name: Joi.string().trim().max(255).optional(),
+  firstName: Joi.string().trim().max(255).required(),
+  lastName: Joi.string().trim().max(255).required(),
   userId: Joi.number().required(),
   age: Joi.number().integer().min(1).max(150).required(),
   gender: Joi.string().valid("male", "female", "other").required(),
@@ -258,9 +258,9 @@ export const onboardFarmerSchema = Joi.object({
 });
 
 export const updateFarmerSchema = Joi.object({
-  name: Joi.string().max(255).optional().allow(null, ""),
-  firstName: Joi.string().max(255).optional().allow(null, ""),
-  lastName: Joi.string().max(255).optional().allow(null, ""),
+  name: Joi.string().trim().max(255).optional().allow(null, ""),
+  firstName: Joi.string().trim().max(255).optional().allow(null, ""),
+  lastName: Joi.string().trim().max(255).optional().allow(null, ""),
   age: Joi.number().integer().min(1).max(150).optional().allow(null),
   gender: Joi.string().max(255).valid("male", "female", "other").optional(),
   optionalNumber: Joi.string().max(255).optional().allow(null, ""),

--- a/src/validation/traderValidation.ts
+++ b/src/validation/traderValidation.ts
@@ -1,9 +1,9 @@
 import Joi from "joi";
 
 export const onboardTraderSchema = Joi.object({
-  fullName: Joi.string().max(255).optional(),
-  firstName: Joi.string().max(255).required(),
-  lastName: Joi.string().max(255).required(),
+  fullName: Joi.string().trim().max(255).optional(),
+  firstName: Joi.string().trim().max(255).required(),
+  lastName: Joi.string().trim().max(255).required(),
   businessName: Joi.string().max(255).required(),
   businessAddress: Joi.string().max(255).optional().allow(null, ""),
   mobileNumber: Joi.string().max(15).required(),
@@ -123,9 +123,9 @@ export const onboardTraderSchema = Joi.object({
 });
 
 export const updateTraderSchema = Joi.object({
-  fullName: Joi.string().max(255).optional().allow(null, ""),
-  firstName: Joi.string().max(255).optional().allow(null, ""),
-  lastName: Joi.string().max(255).optional().allow(null, ""),
+  fullName: Joi.string().trim().max(255).optional().allow(null, ""),
+  firstName: Joi.string().trim().max(255).optional().allow(null, ""),
+  lastName: Joi.string().trim().max(255).optional().allow(null, ""),
   businessName: Joi.string().max(255).optional().allow(null, ""),
   businessAddress: Joi.string().max(255).optional().allow(null, ""),
   mobileNumber: Joi.string().max(15).optional().allow(null, ""),


### PR DESCRIPTION
trim name fields in onboarding form
enforce OTP request limit in mobile update APIs