### PR TITLE
fix: user types deletion and cold storage count in mobile

### DIFF
--- a/src/controller/coldStorage.ts
+++ b/src/controller/coldStorage.ts
@@ -86,6 +86,11 @@ export const updateColdStorage = async (req, res) => {
             "Only Admins, Sub Admins or the Agent who onboarded the cold storage within the last 24 hours can update the profile.",
         });
       }
+
+      if (coldStorage.status === REGISTRATION_STATUS.APPROVED)
+        return res
+          .status(403)
+          .json({ message: "Cold Storage is already approved." });
     }
 
     if (payload.ownerName && coldStorage.userId) {

--- a/src/controller/farmer.ts
+++ b/src/controller/farmer.ts
@@ -121,6 +121,9 @@ export const updateFarmer = async (req, res) => {
             "Only Admins, Sub Admins or the Agent who onboarded the farmer within the last 24 hours can update the profile.",
         });
       }
+
+      if (farmer.status === REGISTRATION_STATUS.APPROVED)
+        return res.status(403).json({ message: "Farmer is already approved." });
     }
 
     await updateUserInDB(farmer.userId, { name: payload.name });

--- a/src/controller/traderController.ts
+++ b/src/controller/traderController.ts
@@ -79,6 +79,9 @@ export const updateTrader = async (req, res) => {
             "Only Admins, Sub Admins or the Agent who onboarded the trader within the last 24 hours can update the profile.",
         });
       }
+
+      if (trader.status === REGISTRATION_STATUS.APPROVED)
+        return res.status(403).json({ message: "Trader is already approved." });
     }
 
     if (payload.fullName) {

--- a/src/services/coldStorageService.ts
+++ b/src/services/coldStorageService.ts
@@ -1046,12 +1046,6 @@ export const deleteColdStorageById = async (coldStorageId: number) => {
     await AgentOnboardedUser.destroy({ where: { id: agentOnboardedCs.id } });
   }
 
-  const { isFarmerOnboarded, isColdStorageOnboarded, isTraderOnboarded } =
-    await getRegistrationTypes(coldStorage.mobileNumber);
-
-  if (!isFarmerOnboarded && !isColdStorageOnboarded && !isTraderOnboarded)
-    await User.destroy({ where: { id: coldStorage.userId } });
-
   return { success: true, data: coldStorage };
 };
 

--- a/src/services/farmerServices.ts
+++ b/src/services/farmerServices.ts
@@ -877,12 +877,6 @@ export const deleteFarmerById = async (farmerId: number) => {
     });
   }
 
-  const { isFarmerOnboarded, isColdStorageOnboarded, isTraderOnboarded } =
-    await getRegistrationTypes(farmer.optionalNumber);
-
-  if (!isFarmerOnboarded && !isColdStorageOnboarded && !isTraderOnboarded)
-    await User.destroy({ where: { id: farmer.userId } });
-
   return { success: true, data: farmer };
 };
 

--- a/src/services/traderService.ts
+++ b/src/services/traderService.ts
@@ -603,12 +603,6 @@ export const deleteTraderById = async (traderId: number) => {
     });
   }
 
-  const { isFarmerOnboarded, isColdStorageOnboarded, isTraderOnboarded } =
-    await getRegistrationTypes(trader.mobileNumber);
-
-  if (!isFarmerOnboarded && !isColdStorageOnboarded && !isTraderOnboarded)
-    await User.destroy({ where: { id: trader.userId } });
-
   return { success: true, data: trader };
 };
 

--- a/src/services/userServices.ts
+++ b/src/services/userServices.ts
@@ -1017,6 +1017,21 @@ export const updateMobileService = async (userId, payload) => {
 export const getAdminDashboardStats = async () => {
   const { oneWeekAgo, oneMonthAgo } = getDateRange();
 
+  const startOfMonth = new Date();
+  startOfMonth.setDate(1);
+  startOfMonth.setHours(0, 0, 0, 0);
+
+  const now = new Date();
+
+  const userInclude: any = {
+    model: User,
+    as: "user",
+    attributes: ["id", "name", "hasStartedUsingMobile", "pbVerified"],
+  };
+
+  userInclude.where = { hasStartedUsingMobile: true };
+  userInclude.required = true; // ensures inner join
+
   const [
     pendingKycStats,
     approvedKycStats,
@@ -1029,6 +1044,8 @@ export const getAdminDashboardStats = async () => {
     lastMonthTotalUsersCount,
     mandiAgentsCount,
     lastMonthMandiAgentsCount,
+    coldStorageCount,
+    lastMonthColdStorageCount,
   ] = await Promise.all([
     KycDocument.count({ where: { status: "pending" } }),
     KycDocument.count({ where: { status: "approved" } }),
@@ -1075,6 +1092,12 @@ export const getAdminDashboardStats = async () => {
         createdAt: { [Op.gte]: oneMonthAgo },
         isActive: true,
       },
+    }),
+
+    ColdStorage.count({ include: [userInclude] }),
+    ColdStorage.count({
+      where: { createdAt: { [Op.gte]: startOfMonth, [Op.lte]: now } },
+      include: [userInclude],
     }),
   ]);
 
@@ -1181,6 +1204,10 @@ export const getAdminDashboardStats = async () => {
           : parseFloat(
               ((lastMonthTotalUsersCount / totalUsersCount) * 100).toFixed(0)
             ),
+    },
+    coldStorageStats: {
+      coldStorageCount,
+      lastMonthColdStorageCount,
     },
     recentActivities: activities.slice(0, 5),
   };


### PR DESCRIPTION
1. on deleting all user types in web , user still will persist.
2. restricted to update user registration if it is already approved for agent.
3. coldstorage registration count to show in mobile dashboard.