### PR TITLE
fix: Allow null in license number for mandi agents

### DIFF
--- a/src/validation/mandiAgentValidation.ts
+++ b/src/validation/mandiAgentValidation.ts
@@ -11,7 +11,7 @@ export const createMandiAgentSchema = Joi.object({
   district: Joi.string().required(),
   city: Joi.string().required(),
   pinCode: Joi.string().required(),
-  licenseNumber: Joi.string().optional().allow(null, ""),
+  licenseNumber: Joi.string().optional().allow(null),
   remarks: Joi.string().optional().allow(null, ""),
   mandiIds: Joi.array().items(Joi.number()).required().min(1),
 });
@@ -27,7 +27,7 @@ export const updateMandiAgentSchema = Joi.object({
   district: Joi.string().optional().allow(null, ""),
   city: Joi.string().optional().allow(null, ""),
   pinCode: Joi.string().optional().allow(null, ""),
-  licenseNumber: Joi.string().optional().allow(null, ""),
+  licenseNumber: Joi.string().optional().allow(null),
   remarks: Joi.string().optional().allow(null, ""),
   mandiIds: Joi.array().items(Joi.number()).optional(),
 });


### PR DESCRIPTION
Allow null in license number for mandi agents